### PR TITLE
convert EventForm from ModelForm to TranslationModelForm

### DIFF
--- a/swingtime/forms.py
+++ b/swingtime/forms.py
@@ -2,12 +2,15 @@
 Convenience forms for adding and updating ``Event`` and ``Occurrence``s.
 '''
 from datetime import datetime, date, time, timedelta
+from dateutil import rrule
+
 from django import forms
 from django.forms.utils import to_current_timezone
 from django.utils.translation import ugettext_lazy as _
 from django.forms.widgets import SelectDateWidget
 
-from dateutil import rrule
+from modeltranslation.forms import TranslationModelForm
+
 from .conf import swingtime_settings
 from .models import *
 from . import utils
@@ -382,7 +385,7 @@ class MultipleOccurrenceForm(forms.Form):
         return params
 
 
-class EventForm(forms.ModelForm):
+class EventForm(TranslationModelForm):
     '''
     A simple form for adding and updating Event attributes
 


### PR DESCRIPTION
Has the side-effect of using English in fields that haven't been edited for a given language, but is definitely workable.